### PR TITLE
Add support for etrade holdings by status report as source

### DIFF
--- a/parser/demat/etrade_holdings_bystatus_parser.py
+++ b/parser/demat/etrade_holdings_bystatus_parser.py
@@ -1,0 +1,87 @@
+import operator
+import sys, os
+import pandas as pd
+import typing as t
+import itertools
+
+# from openpyxl import load_workbook
+
+debug = False
+
+script_path = os.path.realpath(__file__)
+script_folder = os.path.dirname(script_path)
+top_folder = os.path.dirname(os.path.dirname(script_folder))
+sys.path.insert(1, os.path.join(top_folder, "utils"))
+from ticker_mapping import ticker_currency_info
+import logger
+import file_utils
+import date_utils
+import share_data_utils
+
+sys.path.insert(1, os.path.join(top_folder, "models"))
+from purchase import Purchase, Price
+
+sellable_sheet_name = "Sellable"
+
+def parse_sellable_row(data: pd.Series) -> t.Optional[Purchase]:
+    logger.debug_log(f"Currently parsing {type(data["Date Acquired"])} row")
+    # skip this row if there is no date or date is not a string
+    if data["Date Acquired"] == None or not isinstance(data["Date Acquired"], str):
+        return None
+    
+    return Purchase(
+        date=date_utils.parse_named_mon(data["Date Acquired"]),
+        purchase_fmv=Price(
+            float(data["Purchase Date FMV"][1:]),
+            ticker_currency_info[data["Symbol"].lower()],
+        ),
+        quantity=data["Sellable Qty."],
+        ticker=data["Symbol"].lower(),
+    )
+
+def parse_sellable(xl: pd.ExcelFile) -> t.List[Purchase]:
+    logger.debug_log(f"Currently parsing {sellable_sheet_name} sheet")
+    sheet_pd = xl.parse(sheet_name=sellable_sheet_name, skiprows=0, header=0)
+    purchases = []
+    for _, data in sheet_pd.iterrows():
+        parsed_purchase = parse_sellable_row(data)
+        if parsed_purchase != None:
+            purchases.append(parsed_purchase)
+    return purchases
+
+
+def parse(input_file_abs_path: str, output_folder_abs_path: str) -> t.List[Purchase]:
+    logger.debug = debug
+    purchases: t.List[Purchase] = []
+    with pd.ExcelFile(input_file_abs_path, engine="openpyxl") as xl:
+        sheet_names = xl.sheet_names
+        logger.log(f"Total sheets being process {sheet_names}")
+        if sellable_sheet_name not in sheet_names:
+            logger.log(
+                f"Excel sheet don't have either {sellable_sheet_name}"
+            )
+            return []
+        purchases = parse_sellable(xl)
+
+        # logger.log_json(espp_purchases)
+        # logger.log_json(rsu_purchases)
+
+    #purchases.sort(
+    #    key=lambda purchase: purchase.date["time_in_millis"],
+    #)
+    file_utils.write_to_file(
+        output_folder_abs_path,
+        "purchases.json",
+        purchases,
+        True,
+    )
+
+    ticker_shares_map: t.Dict[str, list[Purchase]] = {}
+    for ticker, ticker_purchases in itertools.groupby(
+        purchases, key=operator.attrgetter("ticker")
+    ):
+        ticker_shares_map[ticker] = list(ticker_purchases)
+        print(
+            f"{ticker}: Total shares present in the sheet = {sum(map(lambda x:x.quantity, ticker_shares_map[ticker]))}"
+        )
+    return purchases

--- a/run.py
+++ b/run.py
@@ -14,6 +14,7 @@ sys.path.insert(1, os.path.join(script_folder, "models"))
 sys.path.insert(1, os.path.join(script_folder, "models", "itr"))
 import logger
 import etrade_benefit_history_parser
+import etrade_holdings_bystatus_parser
 import faa3_parser
 
 # arguments defaults
@@ -51,8 +52,8 @@ def main():
         action="store",
         default=default_source_mode,
         dest="source_mode",
-        choices=[f"{default_source_mode}"],
-        help=f"Specify the source mode. Currently, only benefit history from etrade is supported, default = {default_source_mode}",
+        choices=[f"{default_source_mode}","etrade_holdings_bystatus"],
+        help=f"Specify the source mode, default = {default_source_mode}",
     )
     parser.add_argument(
         "-cal",
@@ -86,10 +87,16 @@ def main():
 
     logger.debug = args.debug
     etrade_benefit_history_parser.debug = args.debug
+    etrade_holdings_bystatus_parser.debug = args.debug
 
-    purchases = etrade_benefit_history_parser.parse(
-        args.input_excel_file, args.output_folder
-    )
+    if args.source_mode == "etrade_holdings_bystatus":
+        purchases = etrade_holdings_bystatus_parser.parse(
+            args.input_excel_file, args.output_folder
+        )
+    else:
+        purchases = etrade_benefit_history_parser.parse(
+            args.input_excel_file, args.output_folder
+        )
 
     faa3_parser.parse(
         args.calendar_mode, purchases, args.assessment_year, args.output_folder


### PR DESCRIPTION
The holdings by status report from etrade is a simpler source format. It reports the Sellable holdings only. To download:

1. Click on Stock Plan top menu bar
2. Click on Holdings top submenu bar
3. Click on View By Status
4. Click on Download button which will open the popup.
5. Click on Download Expanded which will prompt you to download the ByStatus.xlsx file