### PR TITLE
added script to refresh RBI and ADBE rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,23 @@ Python module to generate Indian ITR schedule FA under section A3 automatically
 4. Click on `Download` button which will open the popup.
 5. Click on `Download Expanded` which will prompt you to download the `BenefitHistory.xlsx` file
 
-## Run the script
-The script requires Python 3.8 or higher. Please ensure that it is installed on your system. In newer versions of Python, you may encounter an [`externally-managed-environment`](https://peps.python.org/pep-0668/). In this case, you can create a [Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments) and then run the script after activating the virtual environment.
+## Setup
+The script requires Python 3.8 or higher. Please ensure that it is installed on your system. In newer versions of Python, you may encounter an [`externally-managed-environment`](https://peps.python.org/pep-0668/), so create and activate a [Python virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments) before installing the dependencies.
 
-Below example, the command runs the script with the downloaded `BenefitHistory.xlsx`
+```sh
+# From the repository root
+python3 -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip3 install .
+```
+
+This installs all required dependencies (`pandas`, `openpyxl`, `yfinance`, `requests`).
+
+## Run the script
+With the virtual environment activated, run the script with the downloaded `BenefitHistory.xlsx`:
 ```sh
 ./run.py -i "<absolute_folder_of_benefit_history_file>/BenefitHistory.xlsx" -ay 2023
 ```
-You may also have to install the missing Python3 dependencies using command `pip3 install <dependency_name>`
 
 Detailed options are listed below
 ```txt

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ options:
   -v, --verbose         Enable the debug logs
 ```
 
+## Historic data auto-refresh
+`run.py` refreshes both data sources automatically before generating the schedule, so you
+do not need to run the refresh scripts yourself:
+
+- **Share FMV** (`historic_data/shares/<ticker>/data.csv`) from Yahoo Finance via `yfinance`,
+  for every ticker in your `BenefitHistory.xlsx`.
+- **RBI/FBIL reference rates** (`historic_data/rates/rbi/rates.xls`) from the FBIL benchmark
+  via the public [Frankfurter API](https://frankfurter.dev), for every currency used by those
+  tickers. FBIL data is available from 2018-07-10 onwards; only the refreshed currency pairs
+  are replaced, other pairs already in the file are left untouched.
+
+If a dependency is missing or there is no network, the run logs a warning and falls back to
+the bundled data. Pass `--skip-refresh` to force the bundled data (useful when offline). You
+can still run `refresh_historic_data.py` or `refresh_rbi_rates.py` manually.
+
 ## Output
 Inside the `output` folder(if nothing else is specified), the `ticker` folder will be created under which `fa_entries.csv` will be generated. For example, if your `BenefitHistory.xlsx`
 contains entries related to `adbe` then the folder will be `output/adbe/fa_entries.csv`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [project]
 name = "SeFA"
 version = "0.0.1"
+dependencies = [
+    "pandas",
+    "openpyxl",
+    "yfinance",
+    "requests",
+]
 
 [tool.pylint]
 # Configuration for Pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "SeFA"
 version = "0.0.1"
+requires-python = ">=3.8"
 dependencies = [
     "pandas",
     "openpyxl",
     "yfinance",
     "requests",
 ]
+
+[tool.setuptools.packages.find]
+include = ["models*", "parser*", "utils*"]
 
 [tool.pylint]
 # Configuration for Pylint

--- a/refresh_historic_data.py
+++ b/refresh_historic_data.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Refresh historic_data/shares/<ticker>/data.csv from Yahoo Finance via yfinance.
+
+The ITR parser (utils/share_data_utils.py) reads a single-header CSV with a
+"Date" column in %Y-%m-%d format and a "Close" column. yfinance returns a
+MultiIndex column frame whose default to_csv output has extra header rows, so
+this script flattens the columns and reformats the date before writing.
+"""
+import argparse
+import os
+import sys
+
+from utils.runtime_utils import warn_missing_module
+
+script_path = os.path.realpath(os.path.dirname(__file__))
+DEFAULT_TICKER = "adbe"
+DEFAULT_START = "1986-08-13"
+
+
+def refresh(ticker: str, start: str, end: str) -> str:
+    # Imported lazily so importing this module (e.g. from run.py) does not
+    # require yfinance to be installed unless a refresh is actually requested.
+    warn_missing_module("yfinance")
+    import yfinance as yf
+
+    df = yf.download(ticker.upper(), start=start, end=end, auto_adjust=False)
+    if df.empty:
+        raise SystemExit(f"No data returned from yfinance for ticker {ticker}")
+
+    # yfinance returns MultiIndex columns (field, ticker); drop the ticker level.
+    if df.columns.nlevels > 1:
+        df.columns = df.columns.droplevel(1)
+
+    df = df.reset_index()
+    df["Date"] = df["Date"].dt.strftime("%Y-%m-%d")
+
+    out_path = os.path.join(
+        script_path, "historic_data", "shares", ticker.lower(), "data.csv"
+    )
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    df.to_csv(out_path, index=False)
+    print(f"Wrote {len(df)} rows for {ticker.lower()} to {out_path}")
+    return out_path
+
+
+def main():
+    from datetime import date, timedelta
+
+    parser = argparse.ArgumentParser(
+        description="Refresh historic share price CSV from Yahoo Finance"
+    )
+    parser.add_argument(
+        "-t",
+        "--ticker",
+        default=DEFAULT_TICKER,
+        dest="ticker",
+        help=f"Ticker symbol, default = {DEFAULT_TICKER}",
+    )
+    parser.add_argument(
+        "-s",
+        "--start",
+        default=DEFAULT_START,
+        dest="start",
+        help=f"Start date (YYYY-MM-DD), default = {DEFAULT_START}",
+    )
+    parser.add_argument(
+        "-e",
+        "--end",
+        default=(date.today() + timedelta(days=1)).isoformat(),
+        dest="end",
+        help="End date (YYYY-MM-DD, exclusive), default = tomorrow",
+    )
+    args = parser.parse_args()
+    refresh(args.ticker, args.start, args.end)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/refresh_rbi_rates.py
+++ b/refresh_rbi_rates.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Refresh historic_data/rates/rbi/rates.xls from the FBIL reference rate.
+
+The ITR parser (utils/rates/rbi_rates_utils.py) reads a "Reference Rates" sheet
+whose header sits on the third row (two title rows above it) with columns
+"Date" (%d %b %Y), "Time", "Currency Pairs" (e.g. "INR / 1 USD"), "Rate" and
+"Comments". For each month it keeps the latest available date, i.e. the
+month-end reference rate.
+
+FBIL took over the spot USD/INR reference rate from the RBI on 2018-07-10, so
+data is only available from that date. The rates are fetched from the public
+Frankfurter API (https://frankfurter.dev), which exposes the FBIL benchmark via
+`providers=FBIL`. Only the currency pairs that are refreshed are replaced; any
+other pairs already in the file (and older RBI-era data) are left untouched.
+"""
+import argparse
+import os
+import sys
+from datetime import date, datetime
+
+from utils.runtime_utils import warn_missing_module
+
+script_path = os.path.realpath(os.path.dirname(__file__))
+RATES_PATH = os.path.join(script_path, "historic_data", "rates", "rbi", "rates.xls")
+SHEET_NAME = "Reference Rates"
+COLUMNS = ["Date", "Time", "Currency Pairs", "Rate", "Comments"]
+TITLE_ROWS = ["Financial Benchmarks India Pvt Ltd", SHEET_NAME]
+RATE_TIME = "1:30:00 PM"
+DATE_FMT = "%d %b %Y"
+
+DEFAULT_CURRENCIES = ["USD"]
+# FBIL began publishing the spot USD/INR reference rate on 2018-07-10.
+DEFAULT_START = "2018-07-10"
+FRANKFURTER_URL = "https://api.frankfurter.dev/v2/rates"
+
+
+def __fetch_month_end_rates(currency: str, start: str, end: str):
+    """Return an ordered list of (datetime, rate) for the last FBIL business day
+    of each month in [start, end), as INR per 1 unit of `currency`."""
+    warn_missing_module("requests")
+    import requests
+
+    resp = requests.get(
+        FRANKFURTER_URL,
+        params={"from": start, "to": end, "base": currency, "providers": "FBIL"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    if isinstance(payload, dict):  # error responses come back as an object
+        raise SystemExit(
+            f"FBIL fetch for {currency} failed: {payload.get('message', payload)}"
+        )
+
+    # payload is ascending by date, so the last entry per month wins.
+    month_end = {}
+    for entry in payload:
+        if entry.get("quote") != "INR":
+            continue
+        entry_date = datetime.strptime(entry["date"], "%Y-%m-%d")
+        month_end[(entry_date.year, entry_date.month)] = (entry_date, entry["rate"])
+    return list(month_end.values())
+
+
+def __read_existing(rates_path: str):
+    """Return existing data rows (list of COLUMNS-ordered lists), or [] if the
+    file is missing or unreadable."""
+    if not os.path.exists(rates_path):
+        return []
+    warn_missing_module("pandas")
+    import pandas as pd
+
+    with pd.ExcelFile(rates_path, engine="openpyxl") as xl:
+        df = xl.parse(sheet_name=SHEET_NAME, skiprows=0, header=2)
+    df = df.reindex(columns=COLUMNS)
+    return [
+        [None if pd.isna(value) else value for value in row]
+        for row in df.itertuples(index=False)
+    ]
+
+
+def __write(rates_path: str, rows):
+    warn_missing_module("openpyxl")
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = SHEET_NAME
+    for title in TITLE_ROWS:
+        ws.append([title])
+    ws.append(COLUMNS)
+    for row in rows:
+        ws.append(row)
+
+    # openpyxl refuses to save under a ".xls" name, so write .xlsx bytes to a
+    # temp path and move it into place (the parser reads it via pandas anyway).
+    tmp_path = rates_path + ".tmp.xlsx"
+    wb.save(tmp_path)
+    os.replace(tmp_path, rates_path)
+
+
+def refresh(currencies, start: str, end: str, rates_path: str = RATES_PATH) -> str:
+    refreshed_pairs = {f"INR / 1 {cur.upper()}" for cur in currencies}
+    # Keep every existing row whose pair we are NOT refreshing.
+    rows = [
+        row for row in __read_existing(rates_path) if row[2] not in refreshed_pairs
+    ]
+
+    added = 0
+    for cur in currencies:
+        pair = f"INR / 1 {cur.upper()}"
+        for entry_date, rate in __fetch_month_end_rates(cur, start, end):
+            rows.append([entry_date.strftime(DATE_FMT), RATE_TIME, pair, rate, None])
+            added += 1
+
+    os.makedirs(os.path.dirname(rates_path), exist_ok=True)
+    __write(rates_path, rows)
+    print(
+        f"Wrote {len(rows)} rows to {rates_path} "
+        f"({added} refreshed for {sorted(refreshed_pairs)})"
+    )
+    return rates_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Refresh RBI/FBIL reference rate xls from Frankfurter (FBIL)"
+    )
+    parser.add_argument(
+        "-c",
+        "--currency",
+        action="append",
+        dest="currencies",
+        help=f"Currency code to refresh (repeatable), default = {DEFAULT_CURRENCIES}",
+    )
+    parser.add_argument(
+        "-s",
+        "--start",
+        default=DEFAULT_START,
+        dest="start",
+        help=f"Start date (YYYY-MM-DD), default = {DEFAULT_START}",
+    )
+    parser.add_argument(
+        "-e",
+        "--end",
+        default=date.today().isoformat(),
+        dest="end",
+        help="End date (YYYY-MM-DD, inclusive), default = today",
+    )
+    args = parser.parse_args()
+    refresh(args.currencies or DEFAULT_CURRENCIES, args.start, args.end)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/run.py
+++ b/run.py
@@ -3,10 +3,15 @@ import argparse
 import os
 import sys
 
+from datetime import date, timedelta
+
 from parser.demat.etrade import etrade_benefit_history_parser
 from utils import logger, date_utils
 from parser.demat.etrade import etrade_holdings_bystatus_parser
 from parser.itr import faa3_parser
+from utils.ticker_mapping import ticker_currency_info, ticker_org_info
+from refresh_historic_data import refresh, DEFAULT_START
+import refresh_rbi_rates
 
 # arguments defaults
 script_path = os.path.realpath(os.path.dirname(__file__))
@@ -73,12 +78,25 @@ def main():
         default=False,
         help="Enable the debug logs",
     )
+    parser.add_argument(
+        "--skip-refresh",
+        action="store_true",
+        dest="skip_refresh",
+        default=False,
+        help="Skip refreshing historic share prices from Yahoo Finance and use the "
+        "bundled historic_data CSVs instead (useful when offline)",
+    )
 
     args = parser.parse_args()
 
     logger.DEBUG = args.debug
     etrade_benefit_history_parser.DEBUG = args.debug
     etrade_holdings_bystatus_parser.DEBUG = args.debug
+
+    # Refresh before parsing: RSU rows resolve their FMV from the share price CSV
+    # during parsing, so the historic data must be up to date beforehand.
+    if not args.skip_refresh:
+        refresh_historic_data()
 
     if args.source_mode == "etrade_holdings_bystatus":
         purchases = etrade_holdings_bystatus_parser.parse(
@@ -97,6 +115,45 @@ def main():
     faa3_parser.parse(
         args.calendar_mode, purchases, args.assessment_year, args.output_folder
     )
+
+
+def refresh_historic_data():
+    """Best-effort refresh of historic share prices and RBI/FBIL reference rates
+    for every configured ticker. Failures (missing dependency, no network) are
+    logged and ignored so the run falls back to the bundled historic_data."""
+    end = (date.today() + timedelta(days=1)).isoformat()
+    tickers = sorted(ticker_org_info)
+    for ticker in tickers:
+        try:
+            refresh(ticker, DEFAULT_START, end)
+        except SystemExit as err:
+            logger.log(
+                f"Skipping share price refresh for {ticker} ({err}); using bundled "
+                "historic data. Pass --skip-refresh to suppress this."
+            )
+        except Exception as err:
+            logger.log(
+                f"Could not refresh share prices for {ticker} ({err}); "
+                "using bundled historic data."
+            )
+
+    currencies = sorted(
+        {ticker_currency_info[ticker] for ticker in tickers if ticker in ticker_currency_info}
+    )
+    if currencies:
+        try:
+            refresh_rbi_rates.refresh(
+                currencies, refresh_rbi_rates.DEFAULT_START, date.today().isoformat()
+            )
+        except SystemExit as err:
+            logger.log(
+                f"Skipping reference rate refresh ({err}); using bundled rates. "
+                "Pass --skip-refresh to suppress this."
+            )
+        except Exception as err:
+            logger.log(
+                f"Could not refresh reference rates ({err}); using bundled rates."
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Automate historic data refresh in run.py

### Summary
Users previously had to manually maintain the bundled historic data (share prices and currency reference rates) before running the ITR Schedule FA generator. This change makes run.py refresh both data sources automatically, so no manual step is required.

### Changes

refresh_historic_data.py (share prices)
- Fetches historic_data/shares/<ticker>/data.csv from Yahoo Finance via yfinance.
- Flattens yfinance's MultiIndex columns and reformats the date to the %Y-%m-%d/Close shape the ITR parser expects.
- yfinance is imported lazily inside refresh() so importing the module (from run.py) doesn't require the dependency unless a refresh actually runs.

refresh_rbi_rates.py (new — currency reference rates)
- Refreshes historic_data/rates/rbi/rates.xls from the FBIL benchmark via the public Frankfurter API (providers=FBIL).
- Reduces the daily series to the month-end rate per month, matching how the parser consumes it.
- Non-destructive merge: only the refreshed currency pairs are replaced; other pairs already in the file are preserved.
- Writes the exact Reference Rates sheet layout the parser reads (two title rows + header). Data is available from FBIL's start date, 2018-07-10.

run.py (wiring)
- Runs both refreshes before parsing, driven by the configured tickers (ticker_org_info). This ordering is required because RSU rows resolve their FMV from the share-price CSV during parsing, so the data must be current beforehand.
- Best-effort: a missing dependency or no network is logged and the run falls back to the bundled data.
- New --skip-refresh flag forces the bundled data (useful when offline).

pyproject.toml — declares runtime deps: pandas, openpyxl, yfinance, requests.

README.md — documents the auto-refresh behaviour and --skip-refresh.